### PR TITLE
add pod text to x10client & x10server

### DIFF
--- a/x10client
+++ b/x10client
@@ -3,6 +3,28 @@
 # Copyright (c) 1999-2017 Rob Fugina <robf@fugina.com>
 # Distributed under the terms of the GNU Public License, Version 3.0
 
+=head1 NAME
+
+x10client - use to send a list of x10 events to an x10 server 
+
+=head1 USAGE
+
+Usage:
+
+    x10client event1 event2 event3 ...
+     
+Where event1, event2, event3, etc. each represent an x10 event
+
+=head1 DESCRIPTION
+
+Sends x10 events to an x10 server
+
+=head1 AUTHOR
+
+Rob Fugina <robf@fugina.com>
+
+=cut
+
 use File::Basename;
 
 # this works as long as it's not called through a symlink...

--- a/x10server
+++ b/x10server
@@ -3,6 +3,35 @@
 # Copyright (c) 1999-2017 Rob Fugina <robf@fugina.com>
 # Distributed under the terms of the GNU Public License, Version 3.0
 
+=head1 NAME
+
+x10server - creates a server used to receive events from an x10 client 
+
+=head1 USAGE
+
+Usage:
+
+    x10server [options]
+     
+Where options are:
+
+    1 - turn debug output on
+    0 - turn debug output off
+
+=head1 DESCRIPTION
+
+When called, x10server will fork into the background unless the debug flag is
+set. By default the server looks for a TwoWay controller at /dev/twoway. It
+looks for a file called macros.config for macro definitions, a file called 
+scheduler.config for scheduler definitions, and a file called devices.x10 for
+a list of x10 devices.
+
+=head1 AUTHOR
+
+Rob Fugina <robf@fugina.com>
+
+=cut
+
 use strict;
 
 use X10;


### PR DESCRIPTION
@rfugina This PR adds pod text to the x10client and x10server executables, which will enable man pages to be autogenerated during the build (and get rpmlint to stop complaining about missing man pages).

Note that I have never actually run the x10 perl module nor have I ever owned an x10 device. I've only packaged this module into an rpm. Consequently, some of the pod text may be oversimplified or not completely accurate. I can change the text if need be, or you can close this pr and write your own. Either way works for me.

